### PR TITLE
add clear peer list

### DIFF
--- a/src/QuickEspNow_esp32.cpp
+++ b/src/QuickEspNow_esp32.cpp
@@ -57,6 +57,10 @@ void QuickEspNow::stop () {
     esp_now_unregister_recv_cb ();
     esp_now_unregister_send_cb ();
     esp_now_deinit ();
+    for (size_t i = 0; i < peer_list.get_peer_number(); i++)
+    {
+        peer_list.delete_peer();
+    }
 }
 
 bool QuickEspNow::readyToSendData () {


### PR DESCRIPTION
The `peer_list` class store the added peers but it seems it does not clear them whenever `::stop()` is called, even though the peer is actually removed from the esp_now HAL. 