### PR TITLE
delete local peer_list if peer wasn't able to be registered to esp now

### DIFF
--- a/src/QuickEspNow_esp32.cpp
+++ b/src/QuickEspNow_esp32.cpp
@@ -259,6 +259,10 @@ bool QuickEspNow::addPeer (const uint8_t* peer_addr) {
     auto peer = esp_now_peer_info_t{};
     esp_err_t error = ESP_OK;
 
+    if (peer_list.peer_exists (peer_addr) && !esp_now_is_peer_exist(peer_addr)) {
+        peer_list.delete_peer (peer_addr);
+    }
+
     if (peer_list.peer_exists (peer_addr)) {
         DEBUG_VERBOSE (QESPNOW_TAG, "Peer already exists");
         ESP_ERROR_CHECK (esp_now_get_peer (peer_addr, &peer));


### PR DESCRIPTION
There are some rare cases where the `peer_list` has the peer entry, but the esp_now does not. causing hard fault. 

When adding a new peer, if that peer exists in the local buffer, but not in the esp now itself, then there is no point of keeping it in the buffer.