### PR TITLE
Flxbot firmware

### DIFF
--- a/src/QuickEspNow_esp32.cpp
+++ b/src/QuickEspNow_esp32.cpp
@@ -51,6 +51,14 @@ bool QuickEspNow::begin (uint8_t channel, uint32_t wifi_interface, bool synchron
 }
 
 void QuickEspNow::stop () {
+    enableTransmit(false);
+
+    unsigned long start = millis();
+    while ((!readyToSend || uxQueueMessagesWaiting(tx_queue) > 0) &&
+           millis() - start < 200) {
+        delay(1);
+    }
+
     DEBUG_INFO (QESPNOW_TAG, "-------------> ESP-NOW STOP");
     vTaskDelete (espnowTxTask);
     vTaskDelete (espnowRxTask);

--- a/src/QuickEspNow_esp32.cpp
+++ b/src/QuickEspNow_esp32.cpp
@@ -267,6 +267,10 @@ bool QuickEspNow::addPeer (const uint8_t* peer_addr) {
     auto peer = esp_now_peer_info_t{};
     esp_err_t error = ESP_OK;
 
+    if (peer_list.peer_exists (peer_addr) && !esp_now_is_peer_exist(peer_addr)) {
+        peer_list.delete_peer (peer_addr);
+    }
+
     if (peer_list.peer_exists (peer_addr)) {
         DEBUG_VERBOSE (QESPNOW_TAG, "Peer already exists");
         ESP_ERROR_CHECK (esp_now_get_peer (peer_addr, &peer));


### PR DESCRIPTION
This PR 

- fixes a bug where stop would incorrectly delete the tasks, while there is a message in flight
- quickespnow keeps track of an additional peer list, apart from the esp32's internal one, apparently list is not synchronized properly between multiple tasks, in a case where peer_list.peer_exists returns true, but internal esp_now_is_peer_exist returns false, the logic crashes causing panic.